### PR TITLE
Fix the "attachments" property on the site definition entities

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -24,10 +24,12 @@ async function run(): Promise<void> {
     const home = getSiteDefinition(directoryTree, rootDefinition, workingDirectory);
 
     let outputPath = '';
+
     if (workingDirectory) {
       fs.ensureDirSync(workingDirectory);
       outputPath = `${workingDirectory}/`;
     }
+
     fs.writeFileSync(`${outputPath}site.yaml`, JSON.stringify({ spaceKey, home }));
   } catch (error) {
     core.setFailed(error.message);

--- a/src/site-definition.ts
+++ b/src/site-definition.ts
@@ -23,52 +23,84 @@ interface Attachment {
  * Generates the Site Definition object which will be consumed by the Confluence.
  * @param {DirectoryTree} directoryTree Directory tree object that needs to be mapped to the Site Definition object.
  * @param {SiteDefinition} siteDefinition Initial site definition.
- * @param {string} workingDirectory A prefix of the path that will be removed from the final uri value.
+ * @param {string} workingDirectory A prefix of the path that will be removed from the final uri value of each site definition entity.
  */
 export function getSiteDefinition(
-  directoryTree: DirectoryTree,
+  { children = [], name, path, type }: DirectoryTree,
   siteDefinition: SiteDefinition,
-  workingDirectory?: string
+  workingDirectory: string
 ): SiteDefinition {
-  if (directoryTree.type === 'directory') {
-    const {
-      children: childEntities = [],
-      name: directoryName,
-      path: directoryPath,
-    } = directoryTree;
-
-    siteDefinition.name = replaceUnderscoresWithSpaces(directoryName);
-
-    siteDefinition.uri = resolveSiteDefinitionUri(directoryPath, workingDirectory);
-
-    const labelsYamlEntity = childEntities.find(({ name }) => name === 'labels.yaml');
-
-    if (labelsYamlEntity) {
-      const labelsFile = fs.readFileSync(labelsYamlEntity.path, { encoding: 'utf8' });
-
-      siteDefinition.labels = YAML.parse(labelsFile);
-    }
-
-    siteDefinition.children = childEntities
-      .filter(({ type }) => type === 'directory')
-      .filter(({ name }) => name !== 'attachments')
-      .map(child => getSiteDefinition(child, {} as SiteDefinition, workingDirectory));
-
-    const attachmentsDirectory = childEntities.find(({ name }) => name === 'attachments');
-
-    siteDefinition.attachments = attachmentsDirectory?.children?.map(({ path, name, type }) => ({
-      uri: substringWorkingDirectory(path, workingDirectory),
-      name,
-      comment: type,
-      version: '1',
-    }));
+  if (type === 'directory') {
+    siteDefinition.name = replaceUnderscoresWithSpaces(name);
+    siteDefinition.uri = getUri(path, workingDirectory);
+    siteDefinition.labels = getLabels(children);
+    siteDefinition.children = getChildren(children, workingDirectory);
+    siteDefinition.attachments = getAttachments(children, workingDirectory);
   }
 
   return siteDefinition;
 }
 
-function resolveSiteDefinitionUri(directoryPath: string, workingDirectory?: string): string {
-  if (workingDirectory != null && directoryPath.startsWith(workingDirectory)) {
+/**
+ * Returns the list of attachments that may be found in the provided directory tree.
+ * If no attachments are found returns `undefined`.
+ * @param directoryTree The directory tree where the attachments will be searched for.
+ * @param workingDirectory A prefix of the path that will be removed from the final uri value of each site definition entity.
+ */
+function getAttachments(
+  directoryTree: DirectoryTree[],
+  workingDirectory: string
+): Attachment[] | undefined {
+  const attachmentsDirectory = directoryTree.find(
+    ({ name, type }) => name === 'attachments' && type === 'directory'
+  );
+
+  return attachmentsDirectory?.children?.map(({ path, name, type }) => ({
+    uri: substringWorkingDirectory(path, workingDirectory),
+    name,
+    comment: type,
+    version: '1',
+  }));
+}
+
+/**
+ * Returns the list of site definition entities that may be found in the provided directory tree.
+ * If no entities are found returns `undefined`.
+ * @param directoryTree The directory tree where the child entities will be searched for.
+ * @param workingDirectory A prefix of the path that will be removed from the final uri value of each site definition entity.
+ */
+function getChildren(
+  directoryTree: DirectoryTree[],
+  workingDirectory: string
+): SiteDefinition[] | undefined {
+  const children = directoryTree
+    .filter(({ type }) => type === 'directory')
+    .filter(({ name }) => name !== 'attachments')
+    .map(child => getSiteDefinition(child, {} as SiteDefinition, workingDirectory));
+
+  return children.length ? children : undefined;
+}
+
+/**
+ * Returns the list of labels from the `labels.yaml` file that may be found in the provided directory tree.
+ * If no labels are found returns `undefined`.
+ * @param directoryTree The directory tree where the `labels.yaml` file will be searched for.
+ */
+function getLabels(directoryTree: DirectoryTree[]): string[] | undefined {
+  const labelsYaml = directoryTree.find(({ name }) => name === 'labels.yaml');
+
+  return labelsYaml
+    ? YAML.parse(fs.readFileSync(labelsYaml.path, { encoding: 'utf8' }))
+    : undefined;
+}
+
+/**
+ * Returns the uri for the the provided directory path. Uri will always have a `README.md` at the end.
+ * @param directoryPath Directory path that needs to be converted to a uri.
+ * @param workingDirectory A prefix of the path that will be removed from the final uri value of each site definition entity.
+ */
+function getUri(directoryPath: string, workingDirectory: string): string {
+  if (directoryPath.startsWith(workingDirectory)) {
     const uri = `${substringWorkingDirectory(directoryPath, workingDirectory)}/README.md`;
     return uri.startsWith('/') ? uri.substring(1, uri.length) : uri;
   } else {
@@ -76,8 +108,13 @@ function resolveSiteDefinitionUri(directoryPath: string, workingDirectory?: stri
   }
 }
 
-function substringWorkingDirectory(directoryPath: string, workingDirectory?: string): string {
-  if (workingDirectory != null && directoryPath.startsWith(workingDirectory)) {
+/**
+ * Cuts the working directory path from the provided directory path and returns the result string.
+ * @param directoryPath Directory path from which the working directory path should be removed.
+ * @param workingDirectory A prefix of the path that will be removed from the final uri value of each site definition entity.
+ */
+function substringWorkingDirectory(directoryPath: string, workingDirectory: string): string {
+  if (directoryPath.startsWith(workingDirectory)) {
     const newPath = directoryPath.substr(workingDirectory.length, directoryPath.length);
     return newPath.startsWith('/') ? newPath.substring(1, newPath.length) : newPath;
   } else {


### PR DESCRIPTION
This PR fixes the following:
- the `name` attribute is being added on site definition entities per each attachment;
- the `attachments` property is now working properly, so that it's rendering `attachment` object per each entity in the attachments folder (previously it was not working);

The ticket which this PR is related to: https://jira.digital.ingka.com/browse/OFDDSM-2093.