### PR TITLE
fix: upgrade node16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,6 @@ inputs:
     required: true
     description: 'Space name'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'
   post: dist/index.js


### PR DESCRIPTION
According to [GIthub recommendations ](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/), we should upgrade the action to node16.